### PR TITLE
Removed bin from index and added to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
The files within `bin` are platform-dependent. Should be removed from index and added to ignore in order to avoid to commit them by mistake.